### PR TITLE
test: cover pagination reset, back-button fallback, and cache-seeding-guards

### DIFF
--- a/src/components/BackButton.test.tsx
+++ b/src/components/BackButton.test.tsx
@@ -1,0 +1,42 @@
+/**
+ * src/components/BackButton.test.tsx
+ *
+ * The whole point of this component is the fallback: `navigate(-1)` on a
+ * location react-router stamped as "default" (a fresh load, refresh, or
+ * direct link — no in-app history to walk back through) would leave the app
+ * or no-op. Mocking react-router directly (rather than driving a real
+ * MemoryRouter) is what lets this test assert on the exact `location.key`
+ * boundary the component branches on, including the "default" sentinel that
+ * a real createBrowserHistory only produces on an actual fresh page load.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { BackButton } from "./BackButton";
+
+const navigate = vi.fn();
+let locationKey = "abc123";
+
+vi.mock("react-router", () => ({
+  useNavigate: () => navigate,
+  useLocation: () => ({ key: locationKey }),
+}));
+
+describe("BackButton", () => {
+  it("walks real history back when there is an in-app entry to return to", () => {
+    locationKey = "abc123";
+    render(<BackButton href="/fallback" />);
+
+    fireEvent.click(screen.getByRole("button"));
+
+    expect(navigate).toHaveBeenCalledWith(-1);
+  });
+
+  it("falls back to href on a fresh load/direct link with no in-app history", () => {
+    locationKey = "default";
+    render(<BackButton href="/fallback" />);
+
+    fireEvent.click(screen.getByRole("button"));
+
+    expect(navigate).toHaveBeenCalledWith("/fallback");
+  });
+});

--- a/src/components/CommunityEntriesSection.test.tsx
+++ b/src/components/CommunityEntriesSection.test.tsx
@@ -1,0 +1,125 @@
+/**
+ * src/components/CommunityEntriesSection.test.tsx
+ *
+ * Covers the two state-adjustment-during-render branches added for
+ * pagination: resetting to page 1 on a season/franchise navigation
+ * (`resetKey` change), and clamping the page back down when the underlying
+ * `entries` array shrinks independent of `resetKey` (a background refetch
+ * returning fewer rows). Both are easy to regress silently since neither
+ * throws — the symptom is a stuck/empty page.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { renderWithProviders } from "../test/renderWithProviders";
+import { CommunityEntriesSection } from "./CommunityEntriesSection";
+import type { Entry } from "../types/database.types";
+
+vi.mock("../supabase-client", () => ({ default: {} }));
+
+let idCounter = 0;
+const makeEntry = (overrides: Partial<Entry> = {}): Entry => ({
+  id: `entry-${(idCounter += 1)}`,
+  created_at: "2026-01-01T00:00:00.000Z",
+  content: null,
+  anime_id: "anime-1",
+  entry_type: "status_update",
+  user_id: "user-1",
+  rating_value: null,
+  status_value: null,
+  franchise_key: null,
+  likes_count: 0,
+  dislikes_count: 0,
+  comment_count: 0,
+  user_vote: null,
+  ...overrides,
+});
+
+const makeEntries = (count: number): Entry[] =>
+  Array.from({ length: count }, () => makeEntry());
+
+const prevPageButton = () =>
+  screen.getByRole("button", { name: "Previous page" });
+const nextPageButton = () => screen.getByRole("button", { name: "Next page" });
+
+describe("CommunityEntriesSection pagination", () => {
+  it("resets to page 1 when resetKey changes", async () => {
+    const user = userEvent.setup();
+    const { rerender } = renderWithProviders(
+      <CommunityEntriesSection
+        entries={makeEntries(25)}
+        emptyMessage="empty"
+        resetKey="season-a"
+      />
+    );
+
+    await user.click(nextPageButton());
+    expect(prevPageButton()).toBeEnabled();
+
+    rerender(
+      <CommunityEntriesSection
+        entries={makeEntries(25)}
+        emptyMessage="empty"
+        resetKey="season-b"
+      />
+    );
+
+    expect(prevPageButton()).toBeDisabled();
+  });
+
+  it("does not reset the page when entries change but resetKey stays the same", async () => {
+    const user = userEvent.setup();
+    const entries = makeEntries(25);
+    const { rerender } = renderWithProviders(
+      <CommunityEntriesSection
+        entries={entries}
+        emptyMessage="empty"
+        resetKey="season-a"
+      />
+    );
+
+    await user.click(nextPageButton());
+    expect(prevPageButton()).toBeEnabled();
+
+    // Same resetKey, new array reference (e.g. a vote mutation patched the
+    // cache) — the page should not snap back to 1.
+    rerender(
+      <CommunityEntriesSection
+        entries={[...entries]}
+        emptyMessage="empty"
+        resetKey="season-a"
+      />
+    );
+
+    expect(prevPageButton()).toBeEnabled();
+  });
+
+  it("clamps the current page down when entries shrinks below it, independent of resetKey", async () => {
+    const user = userEvent.setup();
+    const { rerender } = renderWithProviders(
+      <CommunityEntriesSection
+        entries={makeEntries(25)}
+        emptyMessage="empty"
+        resetKey="season-a"
+      />
+    );
+
+    await user.click(nextPageButton());
+    await user.click(nextPageButton());
+    expect(prevPageButton()).toBeEnabled();
+    expect(nextPageButton()).toBeDisabled();
+
+    // Same resetKey, but the feed query refetched and now returns fewer
+    // entries than would fill the page the viewer was sitting on.
+    rerender(
+      <CommunityEntriesSection
+        entries={makeEntries(5)}
+        emptyMessage="empty"
+        resetKey="season-a"
+      />
+    );
+
+    expect(prevPageButton()).toBeDisabled();
+    expect(nextPageButton()).toBeDisabled();
+  });
+});

--- a/src/hooks/useFranchiseMembers.test.tsx
+++ b/src/hooks/useFranchiseMembers.test.tsx
@@ -1,0 +1,94 @@
+/**
+ * src/hooks/useFranchiseMembers.test.ts
+ *
+ * Covers the cache-seeding side effect's two guards. Neither throws when
+ * broken — the symptom is silent: either a fresher `["anime", id]` entry
+ * (e.g. one AnimeFeed just fetched directly) gets clobbered by a stale
+ * franchise batch response, or every member gets rewritten on every refetch
+ * even when nothing changed.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useFranchiseMembers } from "./useFranchiseMembers";
+import { makeAnime } from "../test/factories";
+
+vi.mock("../supabase-client", () => ({ default: {} }));
+
+const { fetchFranchiseMembers } = vi.hoisted(() => ({
+  fetchFranchiseMembers: vi.fn(),
+}));
+vi.mock("../services/supabase/franchises", () => ({ fetchFranchiseMembers }));
+
+const renderWithClient = (queryClient: QueryClient, franchiseKey: number) => {
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return renderHook(() => useFranchiseMembers(franchiseKey), { wrapper });
+};
+
+describe("useFranchiseMembers cache seeding", () => {
+  it("seeds each member's own anime cache entry from the batch fetch", async () => {
+    const member = makeAnime({ id: "member-1", name: "Season One" });
+    fetchFranchiseMembers.mockResolvedValue([member]);
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+
+    const { result } = renderWithClient(queryClient, 1);
+    await waitFor(() => expect(result.current.franchiseMembers).toBeDefined());
+
+    expect(queryClient.getQueryData(["anime", "member-1"])).toEqual(member);
+  });
+
+  it("does not clobber a fresher anime entry with an older franchise batch response", async () => {
+    const staleMember = makeAnime({ id: "member-1", name: "Stale name" });
+    fetchFranchiseMembers.mockResolvedValue([staleMember]);
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+
+    const freshMember = makeAnime({ id: "member-1", name: "Fresh name" });
+    queryClient.setQueryData(["anime", "member-1"], freshMember, {
+      updatedAt: Date.now() + 60_000, // newer than the batch fetch about to resolve
+    });
+
+    const { result } = renderWithClient(queryClient, 1);
+    await waitFor(() => expect(result.current.franchiseMembers).toBeDefined());
+
+    expect(queryClient.getQueryData(["anime", "member-1"])).toEqual(
+      freshMember
+    );
+  });
+
+  it("skips a redundant rewrite when the cached row already matches the incoming member", async () => {
+    const unchanged = makeAnime({ id: "member-1", name: "Unchanged" });
+    const changed = makeAnime({ id: "member-2", name: "Changed (new)" });
+    fetchFranchiseMembers.mockResolvedValue([unchanged, changed]);
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+
+    queryClient.setQueryData(["anime", "member-1"], unchanged, {
+      updatedAt: 0,
+    });
+    queryClient.setQueryData(
+      ["anime", "member-2"],
+      makeAnime({ id: "member-2", name: "Changed (old)" }),
+      { updatedAt: 0 }
+    );
+
+    const setQueryData = vi.spyOn(queryClient, "setQueryData");
+    const { result } = renderWithClient(queryClient, 1);
+    await waitFor(() => expect(result.current.franchiseMembers).toBeDefined());
+
+    const seededKeys = setQueryData.mock.calls
+      .filter(([key]) => Array.isArray(key) && key[0] === "anime")
+      .map(([key]) => (key as unknown[])[1]);
+
+    expect(seededKeys).toContain("member-2");
+    expect(seededKeys).not.toContain("member-1");
+    expect(queryClient.getQueryData(["anime", "member-2"])).toEqual(changed);
+  });
+});


### PR DESCRIPTION
Adds regression coverage for the non-obvious logic in the recent anime-page work: CommunityEntriesSection's pagination reset/clamp during render, BackButton's location.key "default" fallback, and useFranchiseMembers' cache-seeding freshness/equality guards. Verified each test goes red when its corresponding guard is stripped out.
